### PR TITLE
Series of checks to abort installation if any errors are encounted

### DIFF
--- a/installer/cli.php
+++ b/installer/cli.php
@@ -15,30 +15,6 @@ use Message\Mothership\Install\Project\Init\Initialiser;
  */
 
 try {
-
-	$memory = ini_get('memory_limit');
-
-	switch (substr($memory, -1)) {
-		case 'M':
-		case 'm':
-			$memory = (int) $memory * 1048576;
-			break;
-		case 'K':
-		case 'k':
-			$memory = (int) $memory * 1024;
-			break;
-		case 'G':
-		case 'g':
-			$memory = (int) $memory * 1073741824;
-			break;
-		default:
-			break;
-	}
-
-	if ($memory < 536870912) {
-		$iniSet = ini_set('memory_limit', 536870912);
-	}
-
 	$autoloader = require_once(__DIR__ . '/autoloader.php');
 
 	$optionParser = new OptionParser($argv);

--- a/installer/src/Exception/InstallFailedException.php
+++ b/installer/src/Exception/InstallFailedException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Message\Mothership\Install\Exception;
+
+/**
+ * Generic exception class for installation failures.
+ *
+ * Class InstallFailedException
+ * @package Message\Mothership\Install\Exception
+ */
+class InstallFailedException extends \LogicException
+{
+
+}

--- a/installer/src/FileSystem/DirectoryResolver.php
+++ b/installer/src/FileSystem/DirectoryResolver.php
@@ -145,6 +145,30 @@ class DirectoryResolver
 	}
 
 	/**
+	 * Check to see if a directory is empty
+	 *
+	 * @param $path
+	 *
+	 * @return bool
+	 */
+	public function isEmpty($path)
+	{
+		$path = $this->getAbsolute($path);
+
+		if ($this->exists($path)) {
+			$handle = opendir($path);
+
+			while (false !== ($entry = readdir($handle))) {
+				if ($entry != "." && $entry != "..") {
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	/**
 	 * Get absolute path of directory
 	 *
 	 * @param string $path      Path of directory

--- a/installer/src/Output/ExceptionOutput.php
+++ b/installer/src/Output/ExceptionOutput.php
@@ -47,7 +47,7 @@ class ExceptionOutput extends AbstractOutput
 	 */
 	private function _addExceptionLines()
 	{
-		$this->_addLine(get_class($this->_exception) . ' thrown: ' . $this->_exception->getMessage(), 'black', 'red');
+		$this->_addLine(get_class($this->_exception) . ' thrown: ' . $this->_exception->getMessage(), 'white', 'red');
 		$this->_addLine($this->_exception->getFile() . ' line ' . $this->_exception->getLine(), 'red');
 
 		if ($this->_exception instanceof Exception\OutputException) {

--- a/installer/src/Project/Config/AbstractConfig.php
+++ b/installer/src/Project/Config/AbstractConfig.php
@@ -2,6 +2,7 @@
 
 namespace Message\Mothership\Install\Project\Config;
 
+use Message\Mothership\Install\Exception\InstallFailedException;
 use Message\Mothership\Install\FileSystem\DirectoryResolver;
 use Message\Mothership\Install\Output\QuestionOutput;
 use Message\Mothership\Install\Output\InfoOutput;
@@ -40,9 +41,15 @@ abstract class AbstractConfig implements ConfigInterface
 	 */
 	public function getConfig($path)
 	{
-		return Yaml::parse(file_get_contents(
+		$config = @Yaml::parse(file_get_contents(
 			$this->_dirResolver->getAbsolute(rtrim($path, '/') . '/' . $this->getConfigPath())
 		));
+
+		if (!$config) {
+			throw new InstallFailedException('Could not load config file from `' . $path . '`');
+		}
+
+		return $config;
 	}
 
 	/**

--- a/installer/src/Project/Config/AbstractConfig.php
+++ b/installer/src/Project/Config/AbstractConfig.php
@@ -41,9 +41,9 @@ abstract class AbstractConfig implements ConfigInterface
 	 */
 	public function getConfig($path)
 	{
-		$config = @Yaml::parse(file_get_contents(
-			$this->_dirResolver->getAbsolute(rtrim($path, '/') . '/' . $this->getConfigPath())
-		));
+		$path = $this->_dirResolver->getAbsolute(rtrim($path, '/') . '/' . $this->getConfigPath());
+
+		$config = @Yaml::parse(file_get_contents($path));
 
 		if (!$config) {
 			throw new InstallFailedException('Could not load config file from `' . $path . '`');

--- a/installer/src/Project/Config/AbstractConfig.php
+++ b/installer/src/Project/Config/AbstractConfig.php
@@ -4,6 +4,7 @@ namespace Message\Mothership\Install\Project\Config;
 
 use Message\Mothership\Install\FileSystem\DirectoryResolver;
 use Message\Mothership\Install\Output\QuestionOutput;
+use Message\Mothership\Install\Output\InfoOutput;
 
 use Symfony\Component\Yaml\Yaml;
 

--- a/installer/src/Project/Config/Database/Config.php
+++ b/installer/src/Project/Config/Database/Config.php
@@ -85,7 +85,7 @@ class Config extends AbstractConfig
 		$mysqlConn = 'mysql:host=' . $dbConfig[self::HOST] . ';dbname=' . $dbConfig[self::NAME];
 
 		try {
-			$pdo = new \PDO($mysqlConn, $dbConfig[self::USER], $dbConfig[self::PASS]);
+			$pdo = @new \PDO($mysqlConn, $dbConfig[self::USER], $dbConfig[self::PASS]);
 		} catch (\PDOException $e) {
 			throw new Exception\ConfigException('Install aborted, could not establish database connection. Message: ' . $e->getMessage());
 		} catch (\ErrorException $e) {

--- a/installer/src/Project/Config/Database/Config.php
+++ b/installer/src/Project/Config/Database/Config.php
@@ -2,6 +2,7 @@
 
 namespace Message\Mothership\Install\Project\Config\Database;
 
+use Message\Mothership\Install\Exception\InstallFailedException;
 use Message\Mothership\Install\Project\Config\Exception;
 use Message\Mothership\Install\Project\Config\AbstractConfig;
 
@@ -22,6 +23,13 @@ class Config extends AbstractConfig
 	const PASS    = 'pass';
 	const NAME    = 'name';
 	const CHARSET = 'charset';
+
+	private $_required = [
+		self::HOST,
+		self::USER,
+		self::NAME,
+		self::CHARSET,
+	];
 
 	/**
 	 * {@inheritDoc}
@@ -68,17 +76,24 @@ class Config extends AbstractConfig
 	 */
 	public function validateConfig(array $dbConfig)
 	{
-		$required = [
-			self::HOST,
-			self::USER,
-			self::PASS,
-			self::CHARSET,
-		];
-
-		foreach ($required as $key) {
+		foreach ($this->_required as $key) {
 			if (!array_key_exists($key, $dbConfig) || !$dbConfig[$key]) {
 				throw new Exception\ConfigException('Database details are missing `' . $key . '` option');
 			}
+		}
+
+		$mysqlConn = 'mysql:host=' . $dbConfig[self::HOST] . ';dbname=' . $dbConfig[self::NAME];
+
+		try {
+			$pdo = new \PDO($mysqlConn, $dbConfig[self::USER], $dbConfig[self::PASS]);
+		} catch (\PDOException $e) {
+			throw new Exception\ConfigException('Install aborted, could not establish database connection. Message: ' . $e->getMessage());
+		} catch (\ErrorException $e) {
+			throw new Exception\ConfigException('Install aborted, an error was thrown. Message: ' . $e->getMessage());
+		}
+
+		if ($pdo->query("SHOW TABLES IN " . $dbConfig[self::NAME])->rowCount() > 0) {
+			throw new InstallFailedException('Database schema must be empty!');
 		}
 	}
 }

--- a/installer/src/Project/Init/Initialiser.php
+++ b/installer/src/Project/Init/Initialiser.php
@@ -5,6 +5,7 @@ namespace Message\Mothership\Install\Project\Init;
 use Message\Mothership\Install\Bin\Runner as BinRunner;
 use Message\Mothership\Install\Project\Config\App\Config as AppConfig;
 use Message\Mothership\Install\Project\Config\Database\Config as DbConfig;
+use Message\Mothership\Install\Project\Config\Exception\ConfigException;
 use Message\Mothership\Install\Project\Database\Install as DbInstall;
 use Message\Mothership\Install\Output\QuestionOutput;
 use Message\Mothership\Install\Project\PostInstall\File\Collection as PostInstallFiles;
@@ -88,6 +89,7 @@ class Initialiser
 	public function init($path)
 	{
 		$this->_info->heading('Initialising Mothership installation');
+
 		$this->_appConfig->askForDetails($path);
 
 		$this->_dbConfig->askForDetails($path);
@@ -103,7 +105,7 @@ class Initialiser
 
 		$this->_binRunner->run($path, 'task:run user:create_admin');
 
-		$this->_info->heading('Initialisation complete! Navigate to `[your URL]/admin` in your browser to start adding content');
+		$this->_info->heading('Initialisation complete! Navigate to `[your URL]/admin` in your browser to start adding content. Be sure to check out http://wiki.mothership.ec and http://forum.mothership.ec for more help with setting up your Mothership site!');
 	}
 
 	/**


### PR DESCRIPTION
#### What does this do?

Adds a bunch of checks and error messages to make the reason for the install script breaking a bit clearer. It now checks:

+ That the directory being set up is empty
+ That the theme downloaded from git
+ That a database connection could be established
+ That the database schema is empty

If any of these come out false, and exception is thrown and the script is aborted.

#### How should this be manually tested?

+ Test installing in a non-empty directory
+ Test installing without an internet connection
+ Test installing with incorrect database details
+ Test installing on a non-empty database schema

#### Related PRs / Issues / Resources?

Will make error reporting for issues like https://github.com/mothership-ec/mothership-install/issues/5 a lot clearer

#### Anything else to add? (Screenshots, background context, etc)

