### PR TITLE
Allow installer to be run without php command

### DIFF
--- a/installer/cli.php
+++ b/installer/cli.php
@@ -1,3 +1,4 @@
+#!/usr/bin/env php
 <?php
 
 use Message\Mothership\Install\Exception\InvalidCommandException;


### PR DESCRIPTION
Currently the installer must be run with `php ./mothership.phar`. This should allow us to just run `./mothership.phar`. When testing remember to `chmod +x mothership.phar`.