### PR TITLE
Wrap db name in backticks when validating number of tables in database

### DIFF
--- a/installer/src/Project/Config/Database/Config.php
+++ b/installer/src/Project/Config/Database/Config.php
@@ -94,7 +94,7 @@ class Config extends AbstractConfig implements AskerInterface
 			throw new InstallFailedException('Install aborted, an error was thrown. Message: ' . $e->getMessage());
 		}
 
-		if ($pdo->query("SHOW TABLES IN " . $dbConfig[self::NAME])->rowCount() > 0) {
+		if ($pdo->query("SHOW TABLES IN `" . $dbConfig[self::NAME] . "`")->rowCount() > 0) {
 			throw new InstallFailedException('Database schema must be empty!');
 		}
 	}

--- a/installer/src/Project/Config/Database/Config.php
+++ b/installer/src/Project/Config/Database/Config.php
@@ -84,6 +84,10 @@ class Config extends AbstractConfig implements AskerInterface
 			}
 		}
 
+		if (preg_match('/[\/\\.;`\'"\s]/', $dbConfig[self::NAME])) {
+			throw new Exception\ConfigException('Database name `' . $dbConfig[self::NAME] . '` contains invalid characters');
+		}
+
 		$mysqlConn = 'mysql:host=' . $dbConfig[self::HOST] . ';dbname=' . $dbConfig[self::NAME];
 
 		try {


### PR DESCRIPTION
Installer was causing errors when the database name had hyphens in it. This validates the schema name as well as wrapping it in backticks when checking if the db is empty